### PR TITLE
feat: support named binaries

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
 	},
 	"dependencies": {
 		"execa": "^7.1.1",
-		"get-bin-path": "^8.0.0"
+		"get-bin-path": "^9.0.0"
 	},
 	"devDependencies": {
 		"@tommy-mitchell/tsconfig": "^0.1.0",

--- a/readme.md
+++ b/readme.md
@@ -27,9 +27,72 @@ yarn add --dev bin-path-cli
 ## Usage
 
 ```sh
-# in a directory with your `package.json`
-$ bin-path --some-flag arg1 arg2
+npx bin-path [binary-name] [arguments or flags…]
 ```
+
+### Cuurent Working Directory
+
+Inside of a directory with a `package.json` that specifies a binary either via `bin` or `directories.bin`, run via:
+
+```sh
+npx bin-path
+```
+
+If no binary is found, the `bin-path` command fails.
+
+### Arguments
+
+Flags and arguments are passed as-is to your binary:
+
+```sh
+$ npx bin-path --some-flag arg1 arg2
+```
+
+<details>
+<summary>Example</summary>
+
+```js
+// cli.js
+#!/usr/bin/env node
+import meow from "meow";
+
+const {input} = meow({importMeta: import.meta});
+console.log(`Arguments: [${input.join(", ")}]`);
+```
+
+```sh
+$ npx bin-path arg1 arg2
+#=> "Arguments: [arg1, arg2]"
+```
+</details>
+
+### Named binaries
+
+If you have multiple exported binaries, they can be accessed by name if passed as the first argument to `bin-path`:
+
+```sh
+$ npx bin-path binary-name
+```
+
+<details>
+<summary>Example</summary>
+
+```jsonc
+// package.json
+"bin": {
+	"foo": "./foo.js",
+	"bar": "./bar.js"
+}
+```
+
+```sh
+# `foo` binary
+$ npx bin-path foo --foo-flag
+
+# `bar` binary
+$ npx bin-path bar --bar-flag
+```
+</details>
 
 ## Related
 

--- a/readme.md
+++ b/readme.md
@@ -30,7 +30,7 @@ yarn add --dev bin-path-cli
 npx bin-path [binary-name] [arguments or flags…]
 ```
 
-### Cuurent Working Directory
+### Curent Working Directory
 
 Inside of a directory with a `package.json` that specifies a binary either via `bin` or `directories.bin`, run via:
 
@@ -91,6 +91,26 @@ $ npx bin-path foo --foo-flag
 
 # `bar` binary
 $ npx bin-path bar --bar-flag
+```
+</details>
+
+Omitting a name searches for a binary with the same name as the project (i.e. `name` in `package.json`). This is the "default" binary.
+
+<details>
+<summary>Example</summary>
+
+```jsonc
+// package.json
+"name": "foo",
+"bin": {
+	"foo": "./foo.js",
+	"bar": "./bar.js"
+}
+```
+
+```sh
+# `foo` binary
+$ npx bin-path --foo-flag
 ```
 </details>
 

--- a/readme.md
+++ b/readme.md
@@ -96,4 +96,4 @@ $ npx bin-path bar --bar-flag
 
 ## Related
 
-- [get-bin-path](https://github.com/ehmicky/get-bin-path) - The library used to build this.
+- [get-bin-path](https://github.com/ehmicky/get-bin-path) - Get the current package's binary path.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -20,7 +20,7 @@ const exit = ({message, exitCode = 1}: ExitOptions = {}) => {
 // First two arguments are Node binary and this binary
 const args = process.argv.slice(2);
 
-/** Attempt to get a named binary from the first argument, fallback to default binary. */
+/** Attempt to get a named binary from the first argument, or fallback to default binary. */
 const tryGetBinPath = async (binaryName?: string): ReturnType<typeof getBinPath> => {
 	if(binaryName) {
 		const binPath = await getBinPath({name: binaryName});

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -41,7 +41,7 @@ const maybeBinaryName = args.at(0);
 const binPath = await tryGetBinPath(maybeBinaryName);
 
 if(!binPath) {
-	exit({message: "No binary found."});
+	exit({message: "No binary found. Usage: `$ npx bin-path [binary-name] [arguments or flags…]`"});
 }
 
 try {

--- a/test/fixtures/named-binaries/no-default/bar.js
+++ b/test/fixtures/named-binaries/no-default/bar.js
@@ -1,0 +1,3 @@
+#!/usr/bin/env node
+
+console.log("bar");

--- a/test/fixtures/named-binaries/no-default/foo.js
+++ b/test/fixtures/named-binaries/no-default/foo.js
@@ -1,0 +1,3 @@
+#!/usr/bin/env node
+
+console.log("foo");

--- a/test/fixtures/named-binaries/no-default/package.json
+++ b/test/fixtures/named-binaries/no-default/package.json
@@ -1,0 +1,8 @@
+{
+	"name": "baz",
+	"bin": {
+		"foo": "./foo.js",
+		"bar": "./bar.js"
+	},
+	"type": "module"
+}

--- a/test/fixtures/named-binaries/with-default/bar.js
+++ b/test/fixtures/named-binaries/with-default/bar.js
@@ -1,0 +1,3 @@
+#!/usr/bin/env node
+
+console.log("bar");

--- a/test/fixtures/named-binaries/with-default/foo.js
+++ b/test/fixtures/named-binaries/with-default/foo.js
@@ -1,0 +1,3 @@
+#!/usr/bin/env node
+
+console.log("foo");

--- a/test/fixtures/named-binaries/with-default/package.json
+++ b/test/fixtures/named-binaries/with-default/package.json
@@ -1,0 +1,8 @@
+{
+	"name": "foo",
+	"bin": {
+		"foo": "./foo.js",
+		"bar": "./bar.js"
+	},
+	"type": "module"
+}

--- a/test/test.ts
+++ b/test/test.ts
@@ -8,6 +8,7 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 const test = anyTest as TestFn<{
 	binPath: string;
+	helpText: string;
 }>;
 
 test.before("get bin path", async t => {
@@ -16,6 +17,10 @@ test.before("get bin path", async t => {
 	t.truthy(binPath, "No bin path found!");
 
 	t.context.binPath = binPath!;
+});
+
+test.before("setup context", t => {
+	t.context.helpText = "No binary found. Usage: `$ npx bin-path [binary-name] [arguments or flags…]`";
 });
 
 const atFixture = (name: string): Options => ({cwd: `${__dirname}/fixtures/${name}`});
@@ -42,7 +47,7 @@ test("no bin", async t => {
 	);
 
 	t.is(error?.exitCode, 1);
-	t.is(error?.stderr, "No binary found.");
+	t.is(error?.stderr, t.context.helpText);
 });
 
 test("accepts arguments", async t => {
@@ -84,5 +89,5 @@ test("named binary - no default", async t => {
 	const error = await t.throwsAsync<ExecaError>(execa(t.context.binPath, [], atFixture("named-binaries/no-default")));
 
 	t.is(error?.exitCode, 1);
-	t.is(error?.stderr, "No binary found.");
+	t.is(error?.stderr, t.context.helpText);
 });

--- a/test/test.ts
+++ b/test/test.ts
@@ -56,3 +56,33 @@ test("accepts arguments", async t => {
 	await run([], "Arguments: []");
 	await run(["1", "2", "3"], "Arguments: [1, 2, 3]");
 });
+
+test("named binary - with default", async t => {
+	const run = async (args: string[], expected: string) => {
+		const {exitCode, stdout} = await execa(t.context.binPath, args, atFixture("named-binaries/with-default"));
+
+		t.is(exitCode, 0);
+		t.is(stdout, expected);
+	};
+
+	await run(["foo"], "foo");
+	await run(["bar"], "bar");
+	await run([], "foo");
+});
+
+test("named binary - no default", async t => {
+	const run = async (args: string[], expected: string) => {
+		const {exitCode, stdout} = await execa(t.context.binPath, args, atFixture("named-binaries/no-default"));
+
+		t.is(exitCode, 0);
+		t.is(stdout, expected);
+	};
+
+	await run(["foo"], "foo");
+	await run(["bar"], "bar");
+
+	const error = await t.throwsAsync<ExecaError>(execa(t.context.binPath, [], atFixture("named-binaries/no-default")));
+
+	t.is(error?.exitCode, 1);
+	t.is(error?.stderr, "No binary found.");
+});


### PR DESCRIPTION
Adds support for executing binaries by name (if a package has multiple).

<details>
<summary>Example</summary>

```jsonc
// package.json
"bin": {
	"foo": "./foo.js",
	"bar": "./bar.js"
}
```

```sh
# `foo` binary
$ npx bin-path foo --foo-flag

# `bar` binary
$ npx bin-path bar --bar-flag
```
</details>

In [v9.0.0](https://github.com/ehmicky/get-bin-path/releases/tag/9.0.0) of `get-bin-path`, searching for a named binary returns `undefined` if the specified binary isn't found by name. This closes #2.