### PR TITLE
feat: experimental binary source mapping

### DIFF
--- a/.xo-config.json
+++ b/.xo-config.json
@@ -18,6 +18,12 @@
 				"n/file-extension-in-import": ["error", "always", { ".ts": "always" }],
 				"@typescript-eslint/prefer-regexp-exec": "off"
 			}
+		},
+		{
+			"files": "test/fixtures/**/*.*",
+			"rules": {
+				"import/no-extraneous-dependencies": "off"
+			}
 		}
 	]
 }

--- a/.xo-config.json
+++ b/.xo-config.json
@@ -3,7 +3,8 @@
 		"arrow-parens": "off",
 		"quotes": ["error", "double"],
 		"object-curly-spacing": ["error", "always"],
-		"object-shorthand": ["error", "always", { "avoidExplicitReturnArrows": false }]
+		"object-shorthand": ["error", "always", { "avoidExplicitReturnArrows": false }],
+		"unicorn/no-process-exit": "off"
 	},
 	"overrides": [
 		{

--- a/package.json
+++ b/package.json
@@ -46,6 +46,9 @@
 		"extensions": {
 			"ts": "module"
 		},
+		"environmentVariables": {
+			"concurrency": "5"
+		},
 		"nodeArguments": [
 			"--loader=tsx",
 			"--no-warnings=ExperimentalWarning"
@@ -56,12 +59,14 @@
 		"get-bin-path": "^10.0.0"
 	},
 	"devDependencies": {
+		"@shopify/semaphore": "^3.0.2",
 		"@tommy-mitchell/tsconfig": "^1.1.0",
 		"@types/node": "^16.17",
 		"ava": "^5.3.1",
 		"c8": "^8.0.1",
 		"cross-env": "^7.0.3",
 		"execify-cli": "^0.1.0",
+		"is-executable": "^2.0.1",
 		"listr-cli": "^0.3.0",
 		"meow": "^11.0.0",
 		"tsx": "^3.12.7",

--- a/package.json
+++ b/package.json
@@ -36,8 +36,7 @@
 		"prepare": "npm run build",
 		"build": "tsc -p tsconfig.build.json && execify --pkg --fix-shebang",
 		"lint": "xo",
-		"test": "listr 'tsc --noEmit' 'c8 npm run ava'",
-		"ava": "cross-env NODE_OPTIONS='--loader=ts-node/esm --loader=esmock --no-warnings=ExperimentalWarning' ava"
+		"test": "listr 'tsc --noEmit' 'c8 ava'"
 	},
 	"ava": {
 		"files": [

--- a/package.json
+++ b/package.json
@@ -34,10 +34,10 @@
 	],
 	"scripts": {
 		"prepare": "npm run build",
-		"build": "tsc -p tsconfig.build.json && execify --pkg --fix-shebangs",
+		"build": "tsc -p tsconfig.build.json && execify --pkg --fix-shebang",
 		"lint": "xo",
 		"test": "listr 'tsc --noEmit' 'c8 npm run ava'",
-		"ava": "cross-env NODE_OPTIONS='--loader=tsx --no-warnings=ExperimentalWarning' ava"
+		"ava": "cross-env NODE_OPTIONS='--loader=ts-node/esm --loader=esmock --no-warnings=ExperimentalWarning' ava"
 	},
 	"ava": {
 		"files": [
@@ -50,7 +50,8 @@
 			"concurrency": "5"
 		},
 		"nodeArguments": [
-			"--loader=tsx",
+			"--loader=ts-node/esm",
+			"--loader=esmock",
 			"--no-warnings=ExperimentalWarning"
 		]
 	},
@@ -65,11 +66,13 @@
 		"ava": "^5.3.1",
 		"c8": "^8.0.1",
 		"cross-env": "^7.0.3",
+		"esmock": "^2.3.6",
 		"execify-cli": "^0.1.0",
 		"is-executable": "^2.0.1",
 		"listr-cli": "^0.3.0",
 		"meow": "^11.0.0",
-		"tsx": "^3.12.7",
+		"testtriple": "^2.2.3",
+		"ts-node": "^10.9.1",
 		"typescript": "~5.1.6",
 		"xo": "^0.54.2"
 	}

--- a/readme.md
+++ b/readme.md
@@ -22,12 +22,10 @@ yarn global add bin-path-cli
 ```
 </details>
 
-*Uses top-level await. Requires Node 14.8 or higher.*
-
 ## Usage
 
 ```sh
-npx bin-path [binary-name] [arguments or flags…]
+npx bin-path [source-map] [binary-name] [arguments or flags…]
 ```
 
 ### Curent Working Directory
@@ -54,10 +52,10 @@ $ npx bin-path --some-flag arg1 arg2
 ```js
 // cli.js
 #!/usr/bin/env node
-import meow from "meow";
+import process from "node:process";
 
-const {input} = meow({importMeta: import.meta});
-console.log(`Arguments: [${input.join(", ")}]`);
+const args = process.argv.slice(2);
+console.log(`Arguments: [${args.join(", ")}]`);
 ```
 
 ```sh
@@ -113,6 +111,45 @@ Omitting a name searches for a binary with the same name as the project (i.e. `n
 $ npx bin-path --foo-flag
 ```
 </details>
+
+### Source Mapping
+
+If you're writing your binary in a language that compiles to JavaScript (e.g. TypeScript) and would like to test your source binary, you can map the built file to the source file by using the following format as the first argument to `bin-path`:
+
+```sh
+$ npx bin-path dist.js:::src.ts
+```
+
+<details>
+<summary>Example</summary>
+
+```
+\__ dist/
+    \__ cli.js
+\__ src/
+    \__ cli.ts
+\__ package.json
+```
+
+</details>
+
+#### Notice
+
+This is an experimental feature, currently only available under the `beta` dist-tag. To use, install `bin-path-cli` with:
+
+```sh
+npm install --global bin-path-cli@beta
+```
+
+<details>
+<summary>Other Package Managers</summary>
+
+```sh
+yarn global add bin-path-cli@beta
+```
+</details>
+
+The feature is under-tested and the syntax is subject to change. If you have any problems or suggestings, please [file an issue](https://github.com/tommy-mitchell/bin-path-cli/issues/new).
 
 ## Related
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,44 +1,14 @@
 #!/usr/bin/env tsx
 import process from "node:process";
-import { getBinPath } from "get-bin-path";
 import { execa, type ExecaError } from "execa";
-
-type ExitOptions = {
-	message?: string;
-	exitCode?: number;
-};
-
-/** Exit with an optional error message. */
-const exit = ({ message, exitCode = 1 }: ExitOptions = {}) => {
-	if (message) {
-		console.error(message);
-	}
-
-	process.exit(exitCode);
-};
+import { tryGetBinPath, exit } from "./helpers.js";
 
 // First two arguments are Node binary and this binary
 const args = process.argv.slice(2);
 
-/** Attempt to get a named binary from the first argument, or fallback to default binary. */
-const tryGetBinPath = async (binaryName?: string): ReturnType<typeof getBinPath> => {
-	if (binaryName) {
-		const binPath = await getBinPath({ name: binaryName });
-
-		if (binPath) {
-			args.shift();
-			return binPath;
-		}
-
-		return tryGetBinPath();
-	}
-
-	return getBinPath();
-};
-
 // First argument could be a named binary to use
 const maybeBinaryName = args.at(0);
-const binPath = await tryGetBinPath(maybeBinaryName);
+const binPath = await tryGetBinPath({ args, binaryName: maybeBinaryName });
 
 if (!binPath) {
 	exit({ message: "No binary found. Usage: `$ npx bin-path [binary-name] [arguments or flags…]`" });

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,17 +1,26 @@
-#!/usr/bin/env tsx
+#!/usr/bin/env ts-node-esm
 import process from "node:process";
 import { execa, type ExecaError } from "execa";
-import { tryGetBinPath, exit } from "./helpers.js";
+import { exit, tryGetBinPath, tryMapBinPath } from "./helpers.js";
 
 // First two arguments are Node binary and this binary
 const args = process.argv.slice(2);
 
-// First argument could be a named binary to use
-const maybeBinaryName = args.at(0);
-const binPath = await tryGetBinPath({ args, binaryName: maybeBinaryName });
+const firstArg = args.at(0);
+const shouldMap = firstArg?.includes(":::");
+
+if (shouldMap) {
+	args.shift();
+}
+
+let binPath = await tryGetBinPath({ args });
 
 if (!binPath) {
-	exit({ message: "No binary found. Usage: `$ npx bin-path [binary-name] [arguments or flags…]`" });
+	exit({ message: "No binary found. Usage: `$ npx bin-path [source-map] [binary-name] [arguments or flags…]`" });
+}
+
+if (shouldMap) {
+	binPath = tryMapBinPath({ binPath: binPath!, map: firstArg! });
 }
 
 try {

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,5 +1,6 @@
 import process from "node:process";
 import { getBinPath } from "get-bin-path";
+import type { Match } from "./types.js";
 
 type ExitArgs = {
 	message?: string;
@@ -17,11 +18,13 @@ export const exit = ({ message, exitCode = 1 }: ExitArgs = {}): never => {
 
 type TryGetBinPathArgs = {
 	args: typeof process.argv;
-	binaryName?: string;
 };
 
 /** Attempt to get a named binary from the first argument, or fallback to default binary. */
-export const tryGetBinPath = async ({ args, binaryName }: TryGetBinPathArgs): ReturnType<typeof getBinPath> => {
+export const tryGetBinPath = async ({ args }: TryGetBinPathArgs): ReturnType<typeof getBinPath> => {
+	// First argument could be a named binary to use
+	const binaryName = args.at(0);
+
 	if (binaryName) {
 		const binPath = await getBinPath({ name: binaryName });
 
@@ -32,4 +35,28 @@ export const tryGetBinPath = async ({ args, binaryName }: TryGetBinPathArgs): Re
 	}
 
 	return getBinPath();
+};
+
+/** https://regex101.com/r/OLVdtN/1 */
+const mapRegex = /(?<dPath>[^.]+)(?<dExt>\.\w+):::(?<sPath>[^.]+)(?<sExt>\.\w+)/;
+
+type MapBinPathArgs = {
+	binPath: string;
+	map: string;
+};
+
+/** Maps built binary to source binary if possible. */
+export const tryMapBinPath = ({ binPath, map }: MapBinPathArgs): string => {
+	const match = map.match(mapRegex) as Match<"dPath" | "dExt" | "sPath" | "sExt">;
+
+	if (!match) {
+		return binPath;
+	}
+
+	const {
+		dPath: distPath, dExt: distExtension,
+		sPath: sourcePath, sExt: sourceExtension,
+	} = match.groups;
+
+	return binPath.replace(distPath, sourcePath).replace(distExtension, sourceExtension);
 };

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,0 +1,35 @@
+import process from "node:process";
+import { getBinPath } from "get-bin-path";
+
+type ExitArgs = {
+	message?: string;
+	exitCode?: number;
+};
+
+/** Exit with an optional error message. */
+export const exit = ({ message, exitCode = 1 }: ExitArgs = {}): never => {
+	if (message) {
+		console.error(message);
+	}
+
+	process.exit(exitCode);
+};
+
+type TryGetBinPathArgs = {
+	args: typeof process.argv;
+	binaryName?: string;
+};
+
+/** Attempt to get a named binary from the first argument, or fallback to default binary. */
+export const tryGetBinPath = async ({ args, binaryName }: TryGetBinPathArgs): ReturnType<typeof getBinPath> => {
+	if (binaryName) {
+		const binPath = await getBinPath({ name: binaryName });
+
+		if (binPath) {
+			args.shift();
+			return binPath;
+		}
+	}
+
+	return getBinPath();
+};

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,14 @@
+// Based on https://github.com/microsoft/TypeScript/issues/32098#issuecomment-1279645368
+type RegExpGroups<Groups extends string, Alternates extends string | undefined = undefined> = (
+	RegExpMatchArray & {
+		groups: (
+			| { [name in Groups]: string }
+			| { [name in NonNullable<Alternates>]?: string }
+			| Record<string, string>
+		);
+	}
+);
+
+export type Match<Groups extends string> = RegExpGroups<Groups> | null; // eslint-disable-line @typescript-eslint/ban-types
+
+export type MatchAll<Groups extends string, Alternates extends string> = IterableIterator<RegExpGroups<Groups, Alternates>>;

--- a/test/cli.ts
+++ b/test/cli.ts
@@ -12,7 +12,7 @@ const test = anyTest as TestFn<{
 	permit: Permit;
 }>;
 
-const helpText = "Usage: `$ npx bin-path [binary-name] [arguments or flags…]`";
+const helpText = "Usage: `$ npx bin-path [source-map] [binary-name] [arguments or flags…]`";
 
 test.before("setup context", async t => {
 	const binPath = await getBinPath();
@@ -178,5 +178,13 @@ test("missing binary", verifyCli, {
 	expectations: {
 		exitCode: 1,
 		stderr: "The binary does not exist. Does it need to be built?",
+	},
+});
+
+test("maps dist to src", verifyCli, {
+	fixture: "map",
+	args: "build.js:::source.ts --foo=bar",
+	expectations: {
+		stdout: "bar",
 	},
 });

--- a/test/exit.ts
+++ b/test/exit.ts
@@ -1,0 +1,45 @@
+import test from "ava";
+import esmock from "esmock";
+
+type MacroArgs = [{
+	exitCode?: number;
+	message?: string;
+}];
+
+const verifyHelper = test.macro<MacroArgs>(async (t, { exitCode = 1, message = "" }) => {
+	const verify = (actual: unknown, expected: unknown, name: string) => {
+		const passed = t.is(actual, expected);
+
+		if (!passed) {
+			t.log(`${name}:`, expected);
+		}
+	};
+
+	/* eslint-disable @typescript-eslint/naming-convention, @typescript-eslint/consistent-type-imports */
+	const { exit } = await esmock("../src/helpers.ts", {
+		"node:process": {
+			exit: (code: number) => verify(code, exitCode, "exit code"),
+		},
+		import: {
+			console: {
+				error: (errorMessage: string) => verify(errorMessage, message, "message"),
+			},
+		},
+	}) as typeof import("../src/helpers.js");
+	/* eslint-enable @typescript-eslint/naming-convention, @typescript-eslint/consistent-type-imports */
+
+	exit({ exitCode, message });
+});
+
+test("exits with code 1 and no message by default", verifyHelper, {
+	exitCode: 1,
+	message: "",
+});
+
+test("exits with given code", verifyHelper, {
+	exitCode: 2,
+});
+
+test("exits with given message", verifyHelper, {
+	message: "error message",
+});

--- a/test/fixtures/map/build/cli.js
+++ b/test/fixtures/map/build/cli.js
@@ -1,0 +1,13 @@
+#!/usr/bin/env node
+import meow from "meow";
+
+const cli = meow({
+	importMeta: import.meta,
+	flags: {
+		foo: {
+			type: "string",
+		},
+	},
+});
+
+console.log(cli.flags.foo);

--- a/test/fixtures/map/package.json
+++ b/test/fixtures/map/package.json
@@ -1,0 +1,4 @@
+{
+	"bin": "./dist/cli.js",
+	"type": "module"
+}

--- a/test/fixtures/map/package.json
+++ b/test/fixtures/map/package.json
@@ -1,4 +1,4 @@
 {
-	"bin": "./dist/cli.js",
+	"bin": "./build/cli.js",
 	"type": "module"
 }

--- a/test/fixtures/map/source/cli.ts
+++ b/test/fixtures/map/source/cli.ts
@@ -1,0 +1,13 @@
+#!/usr/bin/env ts-node-esm
+import meow from "meow";
+
+const cli = meow({
+	importMeta: import.meta,
+	flags: {
+		foo: {
+			type: "string",
+		},
+	},
+});
+
+console.log(cli.flags.foo);

--- a/test/try-get-bin-path.ts
+++ b/test/try-get-bin-path.ts
@@ -1,0 +1,67 @@
+import test from "ava";
+import esmock from "esmock";
+import { spy } from "testtriple";
+
+type MacroArgs = [{
+	args: string[];
+	mockResolves?: "binary path" | "undefined";
+	expectations: {
+		args?: string[];
+		binPath: string;
+	};
+}];
+
+const verifyHelper = test.macro<MacroArgs>(async (t, { args, mockResolves, expectations }) => {
+	const assertions = await t.try(async tt => {
+		const { tryGetBinPath } = await esmock("../src/helpers.ts", {
+			"get-bin-path": {
+				getBinPath: mockResolves ? spy(
+					async () => mockResolves === "undefined" ? undefined : "binary path",
+					// @ts-expect-error: testtriple types are incorrect
+					async () => "default binary path",
+				) : async () => "default binary path",
+			},
+		}) as typeof import("../src/helpers.js"); // eslint-disable-line @typescript-eslint/consistent-type-imports
+
+		const testedArgs = [...args];
+		const binPath = await tryGetBinPath({ args: testedArgs });
+
+		tt.is(binPath, expectations.binPath);
+
+		if (expectations.args) {
+			tt.deepEqual(testedArgs, expectations.args);
+		}
+	});
+
+	if (!assertions.passed) {
+		t.log("args:", args);
+		t.log("mockResolves:", mockResolves);
+		t.log("expectations:", expectations);
+	}
+
+	assertions.commit();
+});
+
+test("no binary name - attempts to get default binary", verifyHelper, {
+	args: [],
+	expectations: {
+		binPath: "default binary path",
+	},
+});
+
+test("binary name - falls back to finding default binary if not found", verifyHelper, {
+	args: ["foo", "--bar"],
+	mockResolves: "undefined",
+	expectations: {
+		binPath: "default binary path",
+	},
+});
+
+test("binary name - returns binary path if found and removes first argument", verifyHelper, {
+	args: ["foo", "--bar"],
+	mockResolves: "binary path",
+	expectations: {
+		args: ["--bar"],
+		binPath: "binary path",
+	},
+});

--- a/test/try-map-bin-path.ts
+++ b/test/try-map-bin-path.ts
@@ -23,6 +23,12 @@ test("maps dist to source", verifyHelper, {
 	expected: "src/foo.ts",
 });
 
+test("works with different map", verifyHelper, {
+	binPath: "build/foo.js",
+	map: "build.js:::source.ts",
+	expected: "source/foo.ts",
+});
+
 test("has no effect if map is invalid", verifyHelper, {
 	binPath: "dist/foo.js",
 	map: "dist:::src",

--- a/test/try-map-bin-path.ts
+++ b/test/try-map-bin-path.ts
@@ -1,0 +1,31 @@
+import test from "ava";
+import { tryMapBinPath } from "../src/helpers.js";
+
+type MacroArgs = [{
+	binPath: string;
+	map: string;
+	expected: string;
+}];
+
+const verifyHelper = test.macro<MacroArgs>((t, { binPath, map, expected }) => {
+	const passed = t.is(tryMapBinPath({ binPath, map }), expected);
+
+	if (!passed) {
+		t.log("binPath:", binPath);
+		t.log("map:", map);
+		t.log("expected:", expected);
+	}
+});
+
+test("maps dist to source", verifyHelper, {
+	binPath: "dist/foo.js",
+	map: "dist.js:::src.ts",
+	expected: "src/foo.ts",
+});
+
+test("has no effect if map is invalid", verifyHelper, {
+	binPath: "dist/foo.js",
+	map: "dist:::src",
+	expected: "dist/foo.js",
+});
+

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,4 +5,7 @@
 	"compilerOptions": {
 		"noEmit": true,
 	},
+	"ts-node": {
+		"transpileOnly": true,
+	},
 }


### PR DESCRIPTION
Closes #4.

* Experimentally adds binary source mapping for built binaries
	- Syntax: `npx bin-path dist.js:::src.ts --foo bar`
* Refactors helpers into their own file and adds separate tests

This should be released under `bin-path-cli@beta`.